### PR TITLE
refactor: use copyId instead of isbn for transactions

### DIFF
--- a/common/interface.ts
+++ b/common/interface.ts
@@ -29,6 +29,7 @@ export interface NotificationInfo {
 
 export interface TransactionInfo {
   isbn: string;
+  copyId: string;
   title: string;
   author: string;
   userId: string;
@@ -85,6 +86,19 @@ export interface BookInfoParams {
   isbn: string;
 }
 
+// NOTE: The url param type is hard to use and defined just for clarification
+export type BookCopiesUrlParams =
+  | { borrowedOnly: boolean }
+  | { availableOnly: boolean }
+  | undefined;
+export interface BookCopiesSuccessResponse {
+  copies: string[];
+}
+export type BookCopiesResponse = BookCopiesSuccessResponse | ErrorResponse;
+export interface BookCopiesParams {
+  isbn: string;
+}
+
 export interface BookListSuccessResponse extends PaginationBaseResponse {
   books: BookInfo[];
 }
@@ -97,7 +111,7 @@ export interface BookAddRequest
 export type BookAddResponse = ErrorResponse | undefined;
 
 export interface BookBorrowRequest {
-  isbn: string;
+  copyId: string;
   userId: string;
 }
 export type BookBorrowResponse =
@@ -107,8 +121,7 @@ export type BookBorrowResponse =
     };
 
 export interface BookReturnRequest {
-  isbn: string;
-  userId: string;
+  copyId: string;
 }
 export type BookReturnResponse = ErrorResponse | undefined;
 

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -8,7 +8,7 @@ import {
 import { Button, Input, List } from "antd";
 import axios from "axios";
 import Link from "next/link";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import { useInfiniteQuery } from "react-query";
 import { BookListSuccessResponse } from "../common/interface";
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -34,7 +34,8 @@ function AvatarMenu(props: MenuProps) {
           icon={<PieChartOutlined />}
           className="leading-8"
         >
-          <Link href="/admin">
+          {/* TODO: The overview page is not available */}
+          <Link href={/* "/admin" */ "/admin/books"}>
             <a>Administration</a>
           </Link>
         </Menu.Item>

--- a/mocks/data.ts
+++ b/mocks/data.ts
@@ -1,8 +1,8 @@
 import {
   BookInfo,
-  TransactionInfo,
   CommentInfo,
   NotificationInfo,
+  TransactionInfo,
 } from "../common/interface";
 
 export const users = {
@@ -62,6 +62,7 @@ export const comments: Record<string, CommentInfo[]> = {
 export const transactions: TransactionInfo[] = [
   {
     isbn: "978-1119366447",
+    copyId: "1",
     title: "Professional JavaScript for Web Developers",
     author: "Matt Frisbie",
     userId: "123",
@@ -72,6 +73,7 @@ export const transactions: TransactionInfo[] = [
   },
   {
     isbn: "978-1119366447",
+    copyId: "2",
     title: "Professional JavaScript for Web Developers",
     author: "Matt Frisbie",
     userId: "123",
@@ -81,6 +83,7 @@ export const transactions: TransactionInfo[] = [
   },
   {
     isbn: "978-1260084504",
+    copyId: "3",
     title: "Alice in Wonderland",
     author: "Lewis Carroll",
     userId: "456",
@@ -114,5 +117,20 @@ export const notifications: NotificationInfo[] = [
     date: "2021-11-20",
     message: "Test",
     isRead: false,
+  },
+];
+
+export const copies = [
+  {
+    copyId: "1",
+    isbn: "978-1119366447",
+  },
+  {
+    copyId: "2",
+    isbn: "978-1260084504",
+  },
+  {
+    copyId: "3",
+    isbn: "979-8749522310",
   },
 ];

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -5,6 +5,8 @@ import {
   BookAddResponse,
   BookBorrowRequest,
   BookBorrowResponse,
+  BookCopiesParams,
+  BookCopiesResponse,
   BookInfoParams,
   BookInfoResponse,
   BookListResponse,
@@ -35,7 +37,14 @@ import {
   UserListResponse,
 } from "../common/interface";
 import message from "../common/message.json";
-import { books, comments, notifications, transactions, users } from "./data";
+import {
+  books,
+  comments,
+  copies,
+  notifications,
+  transactions,
+  users,
+} from "./data";
 
 function mockPaginatedData<T>(
   data: Array<T>,
@@ -272,9 +281,7 @@ export const handlers = [
   // TODO: implement comment adding
   rest.post<CommentAddRequest, CommentAddResponse, CommentAddParams>(
     "/api/books/:isbn/comments",
-    (req, res, ctx) => {
-      const isbn = req.params.isbn;
-
+    (_req, res, ctx) => {
       return res(ctx.status(200));
     }
   ),
@@ -296,6 +303,32 @@ export const handlers = [
           ctx.json({
             ...maybeBook,
             borrowed: maybeBorrowed,
+          })
+        );
+      } else {
+        return res(ctx.status(404), ctx.json({ error: message.bookNF }));
+      }
+    }
+  ),
+
+  rest.get<undefined, BookCopiesResponse, BookCopiesParams>(
+    "/api/books/:isbn/copies",
+    (req, res, ctx) => {
+      const isbn = req.params.isbn;
+
+      // TODO: implement filter by params
+      // const borrowedOnly = req.url.searchParams.get("borrowedOnly") === "true";
+      // const availableOnly = req.url.searchParams.get("availableOnly") === "true";
+
+      const copiesForBooks = copies
+        .filter((v) => v.isbn === isbn)
+        .map(({ copyId }) => copyId);
+
+      if (copiesForBooks.length > 0) {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            copies: copiesForBooks,
           })
         );
       } else {
@@ -326,6 +359,7 @@ export const handlers = [
 
     const maybeBook = books.find((book) => book.isbn === isbn);
     if (maybeBook) {
+      copies.push({ copyId: copies.length + 1 + "", isbn });
       maybeBook.available += 1;
     } else if (title === undefined || author === undefined) {
       return res(
@@ -372,12 +406,15 @@ export const handlers = [
   rest.post<BookBorrowRequest, BookBorrowResponse>(
     "/api/borrow",
     (req, res, ctx) => {
-      const { userId, isbn } = req.body;
+      const { userId, copyId } = req.body;
 
       const maybeUser = Object.values(users).find(
         (info) => info.userId === userId
       );
-      const maybeBook = books.find((book) => book.isbn === isbn);
+      const maybeBook = books.find(
+        (book) =>
+          book.isbn === copies.find((copy) => copy.copyId === copyId)?.isbn
+      );
 
       if (!maybeUser) {
         return res(
@@ -404,6 +441,7 @@ export const handlers = [
         transactions.push({
           userId,
           ...maybeBook,
+          copyId,
           date: format(new Date(), "yyyy-MM-dd"),
           dueDate: format(addWeeks(new Date(), 3), "yyyy-MM-dd"),
           fine: 0,
@@ -417,44 +455,33 @@ export const handlers = [
   rest.post<BookReturnRequest, BookReturnResponse>(
     "/api/return",
     (req, res, ctx) => {
-      const { userId, isbn } = req.body;
+      const { copyId } = req.body;
 
-      const maybeUser = Object.values(users).find(
-        (info) => info.userId === userId
+      const maybeTransaction = transactions.find(
+        (transaction) =>
+          transaction.copyId === copyId && transaction.returnDate === undefined
       );
-      const maybeBook = books.find((book) => book.isbn === isbn);
-
-      if (!maybeUser) {
+      if (!maybeTransaction) {
         return res(
           ctx.status(404),
           ctx.json({
-            error: message.userNF,
-          })
-        );
-      } else if (!maybeBook) {
-        return res(
-          ctx.status(404),
-          ctx.json({
-            error: message.bookNF,
+            error: message.bookNotBorrowed,
           })
         );
       } else {
-        const maybeTransaction = transactions.find(
-          (transaction) =>
-            transaction.userId === userId &&
-            transaction.isbn === isbn &&
-            transaction.returnDate === undefined
+        const maybeBook = books.find(
+          (book) => book.isbn === maybeTransaction.isbn
         );
-        if (!maybeTransaction) {
+        if (!maybeBook) {
           return res(
             ctx.status(404),
             ctx.json({
-              error: message.bookNotBorrowed,
+              error: message.bookNF,
             })
           );
         } else {
-          maybeTransaction.returnDate = format(new Date(), "yyyy-MM-dd");
           maybeBook.available += 1;
+          maybeTransaction.returnDate = format(new Date(), "yyyy-MM-dd");
           return res(ctx.status(200));
         }
       }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,11 @@
-import "antd/dist/antd.variable.min.css";
-import "../styles/globals.css";
-import type { AppProps } from "next/app";
-import { Hydrate, QueryClient, QueryClientProvider } from "react-query";
-import UserCtx, { useUserCtxProvider } from "../providers/user";
 import { ConfigProvider, Layout, message } from "antd";
+import "antd/dist/antd.variable.min.css";
+import type { AppProps } from "next/app";
 import { useEffect, useState } from "react";
+import { Hydrate, QueryClient, QueryClientProvider } from "react-query";
 import Header from "../components/Header";
+import UserCtx, { useUserCtxProvider } from "../providers/user";
+import "../styles/globals.css";
 import handleQueryError from "../utils/handleQueryError";
 
 if (process.env.NODE_ENV === "development" && typeof window !== "undefined") {
@@ -22,6 +22,9 @@ function MyApp({ Component, pageProps }: AppProps) {
       new QueryClient({
         defaultOptions: {
           queries: {
+            onError: (err) => handleQueryError(err, message.error),
+          },
+          mutations: {
             onError: (err) => handleQueryError(err, message.error),
           },
         },

--- a/pages/admin/transactions.tsx
+++ b/pages/admin/transactions.tsx
@@ -33,6 +33,7 @@ const TransactionsAdmin: NextPage = () => {
         <Table.Column title="Title" dataIndex="title" key="title" />
         <Table.Column title="Author" dataIndex="author" key="author" />
         <Table.Column title="ISBN" dataIndex="isbn" key="isbn" />
+        <Table.Column title="Copy ID" dataIndex="copyId" key="copyId" />
         <Table.Column title="User ID" dataIndex="userId" key="userId" />
         <Table.Column title="Date" dataIndex="date" key="date" />
         <Table.Column title="Due Date" dataIndex="dueDate" key="dueDate" />

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,3 +1,4 @@
+import { SendOutlined } from "@ant-design/icons";
 import {
   Button,
   Form,
@@ -15,11 +16,10 @@ import {
   UserInfo,
   UserListSuccessResponse,
 } from "../../common/interface";
+import message from "../../common/message.json";
 import { AdminLayout } from "../../components/Layout";
 import usePaginationParams from "../../hooks/usePaginationParams";
 import UserCtx from "../../providers/user";
-import message from "../../common/message.json";
-import { SendOutlined } from "@ant-design/icons";
 
 function NotifyAction({ userId }: { userId: string }) {
   const [form] = Form.useForm();

--- a/pages/center/borrow.tsx
+++ b/pages/center/borrow.tsx
@@ -99,6 +99,7 @@ const Borrowed: NextPage = () => {
         />
         <Table.Column title="Author" dataIndex="author" key="author" />
         <Table.Column title="ISBN" dataIndex="isbn" key="isbn" />
+        <Table.Column title="Copy ID" dataIndex="copyId" key="copyId" />
         <Table.Column title="Borrow Date" dataIndex="date" key="date" />
         <Table.Column
           title="Due Date"


### PR DESCRIPTION
Changes in API:
- `TransactionInfo` is added a new field `copyId`. Affected routes: `/api/user/:userId/borrow`, `/api/transactions`.
- `/api/borrow` accepts `copyId` instead of `isbn`.
- `/api/return` accepts `copyId` instead of `isbn`, and no longer requires `userId`. (Because one copy can only be borrowed by one user at a time)
- A new route `/api/books/:isbn/copies` is introduced to fetch the available copies for one book. It is used to display available copies to select for borrow and return. Interface definition: https://github.com/yioneko/database-course-design-web/blob/eeb4901c9d1853e6ab57d2f791b54209c73bcb1b/common/interface.ts#L89-L100